### PR TITLE
fix(geek): fix left sidebar width media query override issue

### DIFF
--- a/themes/geek/src/style/index.m.scss
+++ b/themes/geek/src/style/index.m.scss
@@ -5,7 +5,7 @@
 
   #home {
     display: grid;
-    grid-template-columns: 68px 1fr 1fr 280px;
+    grid-template-columns: 68px 1fr 1fr 280px !important;
   }
 
   .topicListFooter {


### PR DESCRIPTION
## Summary
Fixed CSS cascade issue in the geek theme where the base #home rule with 14vw sidebar width was overriding the intended 68px width at max-width: 1366px breakpoint.

## Problem
The media query rule `@media (max-width: 1366px) { #home { grid-template-columns: 68px; } }` was not taking effect because the base `#home` rule from index.scss loaded after the media query, causing it to override due to CSS cascade specificity.

## Solution
Added `!important` to the media query rule to ensure it takes precedence at the specified breakpoint: `grid-template-columns: 68px 1fr 1fr 280px !important;`

This approach aligns with existing patterns in the codebase where `!important` is used to handle style overrides (display, border, color rules in index.scss).

## Test Plan
- Build the theme: `pnpm build geek`
- Verify at max-width: 1366px breakpoint that sidebar width is 68px
- Check that responsive design at other breakpoints still works correctly