### PR TITLE
fix(geek): 导航栏「新随笔」「草稿箱」改为仅博主可见

### DIFF
--- a/themes/geek/src/modules/left-sidebar/index.js
+++ b/themes/geek/src/modules/left-sidebar/index.js
@@ -163,13 +163,13 @@ function removeHeaderToLeftSidebar(links) {
       icon: 'fa-pen-square',
       title: '新随笔',
       url: newPost,
-      allowVisit: true,
+      allowVisit: false,
     },
     {
       icon: 'fa-paper-plane',
       title: '草稿箱',
       url: draftBox,
-      allowVisit: true,
+      allowVisit: false,
     },
     {
       icon: 'fa-envelope',


### PR DESCRIPTION
## 背景

Closes #55

Geek 主题左侧导航栏中的「新随笔」「草稿箱」「管理」按钮在代码里写死为所有访客可见,博客园后台的「导航栏控件」设置对其无效。这些均为博主的**管理入口**,访客点击无意义(会跳转登录/管理页)。

## 改动

`themes/geek/src/modules/left-sidebar/index.js` 的 `removeHeaderToLeftSidebar` 中:

- 「新随笔」`allowVisit: true → false`
- 「草稿箱」`allowVisit: true → false`
- 「管理」原本即为 `allowVisit: false`,不变

渲染逻辑 `if (!isOwner && !allowVisit) continue` 保证 `allowVisit: false` 的项**仅博主本人** (`window.isBlogOwner`) 可见。

## 验证

- 修改后文件通过 `vp check` 格式校验
- lint 失败为仓库既有的 oxlint 配置问题(引用了不存在的规则),与本次改动无关