### PR TITLE
fix(markdown): 主题 <mark> 高亮默认色改为亮黄 #FFD54F

### DIFF
--- a/themes/geek/src/style/markdown.scss
+++ b/themes/geek/src/style/markdown.scss
@@ -4,7 +4,7 @@
     blockquoteBg: var(--geek-color-3),
     color-blockquote: var(--geek-color-9),
     blockquoteBorderColor: var(--color-primary),
-    markBg: var(--color-primary),
+    markBg: #ffd54f,
     kbdBg: #fafbfc,
     singleLineCoodeBg: var(--geek-color-2),
     singleLineCoodeColor: #15a7a7,

--- a/themes/reacg/src/style/markdown.scss
+++ b/themes/reacg/src/style/markdown.scss
@@ -4,7 +4,7 @@
     blockquoteBg: var(--color-basic-100),
     color-blockquote: var(--color-basic-600),
     blockquoteBorderColor: var(--color-basic-400),
-    markBg: var(--themeColor),
+    markBg: #ffd54f,
     kbdBg: #fafbfc,
     singleLineCoodeBg: var(--color-basic-200),
     singleLineCoodeColor: #d83b64,

--- a/themes/view/src/style/markdown.scss
+++ b/themes/view/src/style/markdown.scss
@@ -5,7 +5,7 @@ $md: (
   hrColor: var(--color-basic-400),
   blockquoteBg: var(--color-basic-100),
   blockquoteBorderColor: var(--color-basic-400),
-  markBg: var(--themeColor),
+  markBg: #ffd54f,
   kbdBg: #fafbfc,
   singleLineCoodeBg: var(--color-basic-100),
   singleLineCoodeColor: #15a7a7,


### PR DESCRIPTION
## 背景

Closes #58

浅色模式下，博客正文中 `<mark>` 高亮的背景色跟随主题色（深蓝 `#2F63FF`），对比度低、阅读体验差。issue 作者希望能有一个更舒适的高亮色（并提出了亮黄的诉求）。

## 改动

将 `geek` / `view` / `reacg` 三个主题的 `<mark>` 高亮背景色 `markBg` 从主题色引用改为统一的琥珀黄 `#FFD54F`：

| 文件 | 改动 |
|---|---|
| `themes/geek/src/style/markdown.scss` | `markBg: var(--color-primary)` → `#ffd54f` |
| `themes/view/src/style/markdown.scss` | `markBg: var(--themeColor)` → `#ffd54f` |
| `themes/reacg/src/style/markdown.scss` | `markBg: var(--themeColor)` → `#ffd54f` |

## 选色依据

- 黑字配 `#FFD54F`（琥珀黄）对比度充足，符合 WCAG 可访问性要求；
- 相比纯黄 `#ffff00` 视觉更柔和，浅色模式阅读舒适，深色模式下也不会过于刺眼；
- 深浅模式统一使用同一色值，保持改动最小。

## 验证

- 三个主题 `pnpm --filter tona-theme-{geek,view,reacg} build` 全部通过；
- 产物 CSS 中均确认包含 `mark{background-color:#ffd54f}`。